### PR TITLE
Enable CI so that every change is built by github

### DIFF
--- a/.github/workflows/lean_build.yml
+++ b/.github/workflows/lean_build.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+
+jobs:
+  update_lean_xyz_branch_and_build:
+    runs-on: ubuntu-latest
+    name: Update lean-x.y.z branch and build project
+    steps:
+
+    - name: checkout project
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: update branch
+      if: github.ref == 'refs/heads/master'
+      uses: leanprover-contrib/update-versions-action@master
+
+    - name: build project
+      uses: leanprover-contrib/lean-build-action@master


### PR DESCRIPTION
Copied from https://leanprover-community.github.io/ci.html

You'll need to enable actions at https://github.com/l534zhan/my_project/actions before merging this to see its effect.